### PR TITLE
Add configurable day CSS classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanhr-react-calendar",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Simple react calendar",
   "main": "src/main.js",
   "scripts": {

--- a/src/components/DaysRow.react.js
+++ b/src/components/DaysRow.react.js
@@ -13,7 +13,7 @@ module.exports = React.createClass({
     return (
       <tr className="monthDay">
         {_.map(days, function daysToComponent(day, key) {
-          var className = RenderUtils.getDayClassName(day);
+          var className = RenderUtils.getDayClassName(day, component.props.calendar) || "";
           var isToday = moment().isSame(day, 'day');
           var spanClassName = null;
           if(isToday) {

--- a/src/components/EventRow.react.js
+++ b/src/components/EventRow.react.js
@@ -61,7 +61,7 @@ module.exports = React.createClass({
     var components = [];
     for(var i = 0; i < nDays; ++i) {
       var posData = events[i.toString()];
-      var weekendClassName = RenderUtils.getDayClassName(days[i]);
+      var weekendClassName = RenderUtils.getDayClassName(days[i], this.props.calendar);
       if(posData) {
         var className = "event";
         if(posData.type === "summary") {

--- a/src/components/RenderUtils.js
+++ b/src/components/RenderUtils.js
@@ -7,7 +7,14 @@ module.exports = {
     return weekend;
   },
 
-  getDayClassName: function getDayClassName(day) {
+  getDayClassName: function getDayClassName(day, calendar) {
+    if(calendar && calendar.props.dayInfo) {
+      var info = calendar.props.dayInfo(day);
+      if(info) {
+        return info.classes;
+      }
+    }
+
     var className = null;
     if(this.isWeekend(day)) {
       className = "weekend";

--- a/src/demo.js
+++ b/src/demo.js
@@ -147,12 +147,19 @@ function eventClicked(browserEvent, entry) {
   alert(JSON.stringify(entry));
 }
 
+function dayInfo(day) {
+  if(day.isoWeekday() == 6 || day.isoWeekday() == 7) {
+    return {classes:"dayOff"};
+  }
+}
+
 render(
   <Calendar weekDaysHeader={true}
             monthNavigationHeader={true}
             onEventClick={eventClicked}
             month={0}
             year={2016}
+            dayInfo={dayInfo}
             data={data}
             config={config}/>,
   document.getElementById("react-calendar")


### PR DESCRIPTION
Like boostrap-datepicker, when calendar is rendering a day, it will try
to call a fn in calendar named `dayInfo`. This fn may return an object
with a classes string property that will be appended to the day's CSS.
