### PR TITLE
Added much better name to pass a detail component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clanhr-react-calendar",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Simple react calendar",
   "main": "src/main.js",
   "scripts": {

--- a/src/components/EventRow.react.js
+++ b/src/components/EventRow.react.js
@@ -67,8 +67,8 @@ module.exports = React.createClass({
         }
 
         var detail = null;
-        if(posData.type !== "specialDay" && this.props.calendar.props.onEventClick){
-          detail = <EventDetail detail={this.props.calendar.props.onEventClick}
+        if(posData.type !== "specialDay" && this.props.calendar.props.eventDetail){
+          detail = <EventDetail detail={this.props.calendar.props.eventDetail}
                                 event={posData.event}/>
         }
 

--- a/src/demo.js
+++ b/src/demo.js
@@ -173,7 +173,7 @@ var DetailComponent = React.createClass({
 render(
   <Calendar weekDaysHeader={true}
             monthNavigationHeader={true}
-            onEventClick={DetailComponent}
+            eventDetail={DetailComponent}
             month={0}
             year={2016}
             dayInfo={dayInfo}


### PR DESCRIPTION
If you want to see a detail info when click on events you should pass
your detail component via `detailEvent` calendar props
